### PR TITLE
Update services.xml

### DIFF
--- a/Redis/Translation/services.xml
+++ b/Redis/Translation/services.xml
@@ -7,7 +7,7 @@
 >
     <services>
 
-        <service class="SwagEssentials\Redis\Translation\Translation"
+        <service class="SwagEssentials\Redis\Translation\Translation" public="true"
                  id="translation">
             <argument id="dbal_connection" type="service"/>
             <argument id="swag_essentials.redis" type="service"/>


### PR DESCRIPTION
Without this change an export of an emotion world is not possible. 

core.ERROR: Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException: The "translation" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection instead.